### PR TITLE
Fix/lib extensions regex

### DIFF
--- a/src/badigeon/bundle.clj
+++ b/src/badigeon/bundle.clj
@@ -60,7 +60,15 @@
             FileVisitResult/SKIP_SUBTREE
             :else (throw exception)))))
 
-(def ^:const native-extensions #{".so" ".dylib" ".dll" ".a" ".lib"})
+(def ^:const native-extensions
+  #{#"\.so$"
+    #"\.so.[0-9]+$"
+    #"\.so\.[0-9]+\.[0-9]+$"
+    #"\.so\.[0-9]+\.[0-9]+\.[0-9]+$"
+    #"\.dylib$"
+    #"\.dll$"
+    #"\.a$"
+    #"\.lib$"})
 
 (defn- do-extract-native-dependencies
   ([native-prefix coords out-path]
@@ -79,7 +87,7 @@
                  entries (enumeration-seq (.entries jar-file))]
              (doseq [^JarEntry entry entries]
                (let [entry-path (.getName entry)]
-                 (when (and (some #(.endsWith entry-path %) native-extensions)
+                 (when (and (some #(re-find % entry-path) native-extensions)
                             (.startsWith entry-path (str native-prefix)))
                    (let [entry-path (.relativize native-prefix (Paths/get (.getName entry) (make-array String 0)))
                          f-path (.resolve native-path entry-path)]

--- a/src/badigeon/bundle.clj
+++ b/src/badigeon/bundle.clj
@@ -68,7 +68,8 @@
     #"\.dylib$"
     #"\.dll$"
     #"\.a$"
-    #"\.lib$"})
+    #"\.lib$"
+    #"\.scx$"})
 
 (defn- do-extract-native-dependencies
   ([native-prefix coords out-path]


### PR DESCRIPTION
That was an easy fix. Overtone has been using the leiningen's native-path feature to extract some native libs. So it's kind of a special request to allow for .scx extensions, maybe this could be made configureable. I don't think this fileformat conflicts with anything afaik, so it should be harmless. As a major plus for me, I can make overtone compatable with tools-deps thanks yo badigeon :=)