### PR TITLE
make sure that all \ are replaced with / in native-prefix in case of windows

### DIFF
--- a/src/badigeon/bundle.clj
+++ b/src/badigeon/bundle.clj
@@ -89,7 +89,7 @@
         (doseq [^JarEntry entry entries]
           (let [entry-path (.getName entry)]
             (when (and (some #(re-find % entry-path) extensions)
-                       (.startsWith entry-path (str native-prefix)))
+                       (.startsWith entry-path (.replace (.toString native-prefix) "\\" "/")))
               (let [entry-path (.relativize
                                 native-prefix
                                 (Paths/get (.getName entry) (make-array String 0)))


### PR DESCRIPTION
Even if I provide a native-prefix with unix style paths, by the time when it reaches do-extract-native-dependencies, it will be of type sun.nio.fs.WindowsPath with \\ styled seperators.