### PR TITLE
Raise compile exceptions back on the main thread

### DIFF
--- a/src/badigeon/compile.clj
+++ b/src/badigeon/compile.clj
@@ -76,10 +76,18 @@
                        main-method
                        nil
                        (into-array
-                        Object [(into-array String ["--eval" in-script])]))))]
+                        Object [(into-array String ["--eval" in-script])]))))
+         compile-exception (atom nil)
+         ]
+     (.setUncaughtExceptionHandler 
+       t (reify Thread$UncaughtExceptionHandler
+           (^void uncaughtException  [_ ^Thread t ^Throwable e] (reset! compile-exception e))))
      (.start t)
      (.join t)
-     (.close classloader))))
+     (.close classloader)
+     (when-let [exception @compile-exception]
+       (throw (ex-info "Exception during compilation" {} exception)))
+     )))
 
 (defn- extract-classes-from-dependency [path ^Path out-path]
   (let [^Path path (if (string? path)


### PR DESCRIPTION
Because the compile thread has no exception handler, if compile throws an exception it's printed to stderr and then we continue.

This change will trap the exception and re-throw it on the main thread.