### PR TITLE
Migrate project from tools.deps.alpha -> tools.deps 0.18.1354

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.9.0"}
-        org.clojure/tools.deps.alpha {:mvn/version "0.11.910"}}
+        org.clojure/tools.deps {:mvn/version "0.18.1354"}}
  :aliases {:doc {:extra-paths ["src-doc"]}
            :build {:extra-paths ["src-build"]}}}

--- a/src/badigeon/bundle.clj
+++ b/src/badigeon/bundle.clj
@@ -1,9 +1,9 @@
 (ns badigeon.bundle
-  (:require [clojure.tools.deps.alpha :as deps]
+  (:require [clojure.tools.deps :as deps]
             [clojure.java.io :as io]
             [badigeon.utils :as utils]
             [clojure.string :as string]
-            [clojure.tools.deps.alpha.util.maven :as maven])
+            [clojure.tools.deps.util.maven :as maven])
   (:import [java.nio.file Path Paths Files
             FileVisitor FileVisitOption FileVisitResult
             FileSystemLoopException NoSuchFileException FileAlreadyExistsException LinkOption]

--- a/src/badigeon/classpath.clj
+++ b/src/badigeon/classpath.clj
@@ -1,5 +1,5 @@
 (ns badigeon.classpath
-  (:require [clojure.tools.deps.alpha :as deps]
+  (:require [clojure.tools.deps :as deps]
             [clojure.java.io :as io]
             [badigeon.utils :as utils]))
 

--- a/src/badigeon/compile.clj
+++ b/src/badigeon/compile.clj
@@ -1,7 +1,7 @@
 (ns badigeon.compile
   (:require [badigeon.classpath :as classpath]
             [clojure.java.io :as io]
-            [clojure.tools.deps.alpha :as deps]
+            [clojure.tools.deps :as deps]
             [badigeon.utils :as utils])
   (:refer-clojure :exclude [compile])
   (:import [java.nio.file Path Paths Files]
@@ -78,7 +78,7 @@
                         Object [(into-array String ["--eval" in-script])]))))
          compile-exception (atom nil)
          ]
-     (.setUncaughtExceptionHandler 
+     (.setUncaughtExceptionHandler
        t (reify Thread$UncaughtExceptionHandler
            (^void uncaughtException  [_ ^Thread t ^Throwable e] (reset! compile-exception e))))
      (.start t)
@@ -136,7 +136,7 @@
      out-path)))
 
 (comment
-  
+
   (compile '[badigeon.main] {:compile-path "target/classes"
                              :compiler-options {:elide-meta [:doc :file :line :added]}})
 
@@ -145,7 +145,7 @@
     (extract-classes-from-dependencies
      {:deps-map (assoc (deps/slurp-deps (io/file "deps.edn")) :deps '{org.clojure/clojure {:mvn/version "1.9.0"}})
       :excluded-libs #{'org.clojure/clojure}}))
-  
+
   )
 
 ;; Cleaning non project classes: https://dev.clojure.org/jira/browse/CLJ-322
@@ -154,4 +154,4 @@
 ;; Most of the time, libraries should be shipped without AOT. In the rare case when a library must be shipped AOT (let's say we don't want to ship the sources), directories can be removed programmatically, between build tasks. Shipping an application with AOT is a more common use case. In this case, AOT compiling dependencies is not an issue.
 
 ;; Compiling is done in a separate classloader because
-;; - clojure.core/compile recursively compiles a namespace and its dependencies, unless the dependencies are already loaded. :reload-all does not help. Removing the AOT compiled files and recompiling results in a strange result: Source files are not reloaded, no .class file is produced. Using a separate classloader simulates a :reload-all for compile. 
+;; - clojure.core/compile recursively compiles a namespace and its dependencies, unless the dependencies are already loaded. :reload-all does not help. Removing the AOT compiled files and recompiling results in a strange result: Source files are not reloaded, no .class file is produced. Using a separate classloader simulates a :reload-all for compile.

--- a/src/badigeon/deploy.clj
+++ b/src/badigeon/deploy.clj
@@ -1,5 +1,5 @@
 (ns badigeon.deploy
-  (:require [clojure.tools.deps.alpha.util.maven :as maven]
+  (:require [clojure.tools.deps.util.maven :as maven]
             [clojure.java.io :as io]
             [badigeon.utils :as utils])
   (:import [org.eclipse.aether.deployment DeployRequest]

--- a/src/badigeon/install.clj
+++ b/src/badigeon/install.clj
@@ -1,5 +1,5 @@
 (ns badigeon.install
-  (:require [clojure.tools.deps.alpha.util.maven :as maven]
+  (:require [clojure.tools.deps.util.maven :as maven]
             [clojure.java.io :as io])
   (:import [org.eclipse.aether.installation InstallRequest]))
 

--- a/src/badigeon/jar.clj
+++ b/src/badigeon/jar.clj
@@ -1,9 +1,9 @@
 (ns badigeon.jar
-  (:require [clojure.tools.deps.alpha :as deps]
+  (:require [clojure.tools.deps :as deps]
             [badigeon.pom :as pom]
             [badigeon.utils :as utils]
             [clojure.string :as string]
-            [clojure.tools.deps.alpha.util.maven :as maven]
+            [clojure.tools.deps.util.maven :as maven]
             [clojure.java.io :as io])
   (:import [java.nio.file Path Paths Files]
            [java.util EnumSet]
@@ -268,7 +268,7 @@
         :mvn/repos '{"clojars" {:url "https://repo.clojars.org/"}}
         :allow-all-dependencies? true
         :main 'badigeon.main})
-  
+
   )
 
 ;; AOT compilation, no sources in jar -> possibility to set a custom path (target/classes)

--- a/src/badigeon/pom.clj
+++ b/src/badigeon/pom.clj
@@ -4,7 +4,7 @@
             [clojure.zip :as zip]
             [clojure.data.xml.tree :as tree]
             [clojure.data.xml.event :as event]
-            [clojure.tools.deps.alpha.util.maven :as maven]
+            [clojure.tools.deps.util.maven :as maven]
             [badigeon.utils :as utils])
   (:import [java.io File Reader ByteArrayOutputStream]
            [java.nio.file Paths]

--- a/src/badigeon/uberjar.clj
+++ b/src/badigeon/uberjar.clj
@@ -1,5 +1,5 @@
 (ns badigeon.uberjar
-  (:require [clojure.tools.deps.alpha :as deps]
+  (:require [clojure.tools.deps :as deps]
             [badigeon.bundle :as bundle]
             [badigeon.utils :as utils]
             [clojure.java.io :as io])
@@ -263,10 +263,10 @@
 
 (comment
   (merge-resource-conflicts (make-out-path 'badigeon utils/version))
-  
+
   (find-resource-conflicts
    {:deps-map (deps/slurp-deps (io/file "deps.edn")) :aliases [#_:doc]})
-  
+
   (let [out-path (make-out-path 'badigeon utils/version)]
     (badigeon.clean/clean out-path)
     (bundle out-path

--- a/src/badigeon/utils.clj
+++ b/src/badigeon/utils.clj
@@ -1,5 +1,5 @@
 (ns badigeon.utils
-  (:require [clojure.tools.deps.alpha.util.maven :as maven]
+  (:require [clojure.tools.deps.util.maven :as maven]
             [clojure.java.io :as io])
   (:import [java.nio.file Paths Path StandardCopyOption]
            [java.util.jar JarEntry JarOutputStream]

--- a/src/badigeon/war.clj
+++ b/src/badigeon/war.clj
@@ -1,7 +1,7 @@
 (ns badigeon.war
   (:require [clojure.data.xml :as xml]
-            [clojure.tools.deps.alpha :as deps]
-            [clojure.tools.deps.alpha.util.maven :as maven]
+            [clojure.tools.deps :as deps]
+            [clojure.tools.deps.util.maven :as maven]
             [badigeon.utils :as utils]
             [badigeon.bundle :as bundle]
             [badigeon.jar :as jar]
@@ -157,7 +157,7 @@
                                        allow-unstable-deps?
 
                                        manifest
-                                       
+
                                        servlet-version
                                        servlet-name
                                        servlet-class


### PR DESCRIPTION
I know this project is superseded by badigeon2 but we still use 1 feature: the bundle/bundle .
We encountered some issues because we upgraded to tools.deps in most projects.

I've migrated project to use tools.deps instead of tools.deps.alpha (which was superseded). 

I hope you will accept and merge this PR. 

I did test bundle/bundle but nothing else and I did not see any tests to run. 
No release is needed for us since we rely on git branch.